### PR TITLE
Improve filter UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,9 +82,8 @@
             resize: vertical;
         }
         .filter-wrapper {
-            @apply bg-white border border-gray-200 rounded-lg shadow-sm;
+            @apply p-4 bg-white border border-gray-200 rounded-lg shadow-sm;
         }
-        /* Estilos para filtros refinados */
         .filter-group {
             @apply flex flex-col gap-1;
         }
@@ -92,36 +91,7 @@
             @apply text-xs font-medium text-gray-600;
         }
         .filter-input {
-            @apply w-full px-3 py-2 bg-white border border-gray-300 rounded-md text-sm text-gray-700 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-colors shadow-sm hover:border-gray-400;
-        }
-        /* Custom styles for collapsible filter section */
-        .filter-header {
-            @apply flex items-center justify-between cursor-pointer bg-white border border-gray-200 rounded-lg px-5 py-3 transition-colors duration-200 hover:bg-gray-50;
-        }
-        .filter-content {
-            max-height: 0;
-            overflow: hidden;
-            transition: max-height 0.3s ease-out, padding 0.3s ease-out;
-            padding: 0 1.25rem;
-        }
-        .filter-content.expanded {
-            max-height: 700px;
-            transition: max-height 0.5s ease-in, padding 0.3s ease-in;
-            padding: 1.25rem;
-            border: 1px solid #e5e7eb;
-            border-top: none;
-            border-radius: 0 0 0.75rem 0.75rem;
-            background-color: #ffffff;
-        }
-        .filter-header.expanded {
-            border-radius: 0.75rem 0.75rem 0 0;
-            border-bottom: 1px solid #e5e7eb;
-        }
-        .filter-header svg {
-            transition: transform 0.3s ease;
-        }
-        .filter-header.expanded svg {
-            transform: rotate(180deg);
+            @apply w-full px-3 py-2 border border-gray-300 rounded-md text-sm text-gray-700 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none;
         }
     </style>
 </head>
@@ -248,8 +218,7 @@
             eventDateStart: '',
             eventDateEnd: '',
             creationDateStart: '',
-            creationDateEnd: '',
-            isExpanded: false // New property to track filter section state
+            creationDateEnd: ''
         };
 
         // Mapping from filter input IDs to filterState keys for consistent updates
@@ -1403,17 +1372,12 @@
         function renderRecordHistory() {
             // HTML for filter section
             const adminFiltersHtml = userProfile.isAdmin ? `
-                <div id="filters-container" class="filter-wrapper mb-6">
-                    <div id="filter-header" class="filter-header ${filterState.isExpanded ? 'expanded' : ''}">
-                        <h3 class="text-sm font-semibold text-gray-700">Filtros Avançados</h3>
-                        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-gray-500" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" /></svg>
-                    </div>
-                    <div id="filter-content" class="filter-content ${filterState.isExpanded ? 'expanded' : ''}">
-                        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-                            <div class="filter-group">
-                                <label for="filter-search" class="filter-label">Termo Geral:</label>
-                                <input type="text" id="filter-search" class="filter-input" placeholder="Nome, evento, observações..." value="${filterState.searchTerm}">
-                            </div>
+                <div id="filters-container" class="filter-wrapper mb-6 space-y-4">
+                    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+                        <div class="filter-group">
+                            <label for="filter-search" class="filter-label">Termo Geral:</label>
+                            <input type="text" id="filter-search" class="filter-input" placeholder="Nome, evento, observações..." value="${filterState.searchTerm}">
+                        </div>
                             <div class="filter-group">
                                 <label for="filter-event-name" class="filter-label">Nome do Evento:</label>
                                 <input type="text" id="filter-event-name" class="filter-input" placeholder="Ex: Jogo Botafogo vs Flamengo" value="${filterState.eventName}">
@@ -1469,7 +1433,6 @@
                             <button id="btn-clear-filters" class="px-4 py-2 text-sm font-medium bg-gray-200 hover:bg-gray-300 text-gray-700 rounded-lg transition-colors shadow-sm">Limpar Filtros</button>
                             <button id="btn-apply-filters" class="px-4 py-2 text-sm font-medium bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors shadow-sm">Aplicar Filtros</button>
                         </div>
-                    </div>
                 </div>
             ` : '';
 
@@ -1617,17 +1580,12 @@
                         </div>
                     </div>
                     <!-- Nova estrutura de filtros -->
-                    <div id="filters-container" class="filter-wrapper mb-6">
-                        <div id="filter-header" class="filter-header ${filterState.isExpanded ? 'expanded' : ''}">
-                            <h3 class="text-sm font-semibold text-gray-700">Filtros Avançados</h3>
-                            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-gray-500" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" /></svg>
-                        </div>
-                        <div id="filter-content" class="filter-content ${filterState.isExpanded ? 'expanded' : ''}">
-                            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-                                <div class="filter-group">
-                                    <label for="filter-search" class="filter-label">Termo Geral:</label>
-                                    <input type="text" id="filter-search" class="filter-input" placeholder="Nome, evento, observações..." value="${filterState.searchTerm}">
-                                </div>
+                    <div id="filters-container" class="filter-wrapper mb-6 space-y-4">
+                        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+                            <div class="filter-group">
+                                <label for="filter-search" class="filter-label">Termo Geral:</label>
+                                <input type="text" id="filter-search" class="filter-input" placeholder="Nome, evento, observações..." value="${filterState.searchTerm}">
+                            </div>
                                 <div class="filter-group">
                                     <label for="filter-event-name" class="filter-label">Nome do Evento:</label>
                                     <input type="text" id="filter-event-name" class="filter-input" placeholder="Ex: Jogo Botafogo vs Flamengo" value="${filterState.eventName}">
@@ -1683,7 +1641,6 @@
                                 <button id="btn-clear-filters" class="px-4 py-2 text-sm font-medium bg-gray-200 hover:bg-gray-300 text-gray-700 rounded-lg transition-colors shadow-sm">Limpar Filtros</button>
                                 <button id="btn-apply-filters" class="px-4 py-2 text-sm font-medium bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors shadow-sm">Aplicar Filtros</button>
                             </div>
-                        </div>
                     </div>
                     <div id="record-history-table-container">
                         ${generateTableHtml(initialRecordsToDisplay)}
@@ -1802,15 +1759,6 @@
             // Event Listeners for Filter Buttons (Delegated to filters-container)
             const filtersContainer = document.getElementById('filters-container');
             if (filtersContainer) {
-                const filterHeader = document.getElementById('filter-header');
-                const filterContent = document.getElementById('filter-content');
-
-                filterHeader.addEventListener('click', () => {
-                    filterContent.classList.toggle('expanded');
-                    filterHeader.classList.toggle('expanded');
-                    filterState.isExpanded = filterContent.classList.contains('expanded'); // Update state
-                });
-
                 document.getElementById('btn-apply-filters').addEventListener('click', applyFilters);
                 document.getElementById('btn-clear-filters').addEventListener('click', clearFilters);
 


### PR DESCRIPTION
## Summary
- restyle filter section to be always visible and minimalistic
- remove collapsible behavior and update filter state
- streamline filter event listeners

## Testing
- `git diff --color --unified=3 | head -n 40`

------
https://chatgpt.com/codex/tasks/task_e_684a055d53748331810db99929553ca7