### PR TITLE
Adjust filter styling to grayscale

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,9 +82,9 @@
             resize: vertical;
         }
         .filter-wrapper {
-            background: linear-gradient(to right, #f0f9ff, #e0f2fe);
-            padding: 1rem;
-            border: 1px solid #d1e7ff;
+            background: linear-gradient(to right, #f7f7f7, #eeeeee);
+            padding: 0.75rem;
+            border: 1px solid #d1d5db;
             border-radius: 1rem;
             box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
         }
@@ -93,28 +93,28 @@
             flex-direction: column;
             gap: 0.25rem;
             background: #ffffff;
-            border: 1px solid #d1e7ff;
+            border: 1px solid #d1d5db;
             border-radius: 0.5rem;
-            padding: 0.75rem;
+            padding: 0.5rem;
         }
         .filter-label {
-            font-size: 0.75rem;
+            font-size: 0.7rem;
             font-weight: 600;
-            color: #0f609b;
+            color: #374151;
             margin-bottom: 0.25rem;
         }
         .filter-input {
             width: 100%;
-            padding: 0.5rem 0.75rem;
-            border: 1px solid #94a3b8;
+            padding: 0.375rem 0.5rem;
+            border: 1px solid #9ca3af;
             border-radius: 0.375rem;
-            background: #f8fbff;
-            color: #0f172a;
+            background: #f9fafb;
+            color: #374151;
         }
         .filter-input:focus {
             outline: none;
-            border-color: #0ea5e9;
-            box-shadow: 0 0 0 2px #bae6fd;
+            border-color: #6b7280;
+            box-shadow: 0 0 0 2px #d1d5db;
         }
         .filter-toggle summary {
             cursor: pointer;
@@ -122,12 +122,12 @@
             display: flex;
             justify-content: space-between;
             align-items: center;
-            background: #cfe2ff;
-            padding: 0.5rem 1rem;
+            background: #e5e7eb;
+            padding: 0.5rem 0.75rem;
             border-radius: 0.5rem;
-            font-size: 0.875rem;
+            font-size: 0.8rem;
             font-weight: 500;
-            color: #084298;
+            color: #374151;
         }
         .filter-toggle summary::-webkit-details-marker {
             display: none;


### PR DESCRIPTION
## Summary
- modernize filter visuals with gray tones
- reduce font sizes and input padding for compact filters

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684ae46934ec8331b05418f8cf621a15