### PR TITLE
Add auto UID/profile creation on user registration

### DIFF
--- a/index.html
+++ b/index.html
@@ -2032,17 +2032,12 @@
                         <button id="btn-back-manage-users" class="px-3 py-2 text-xs font-medium bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-lg transition-colors">Voltar para Gerenciar</button>
                     </div>
                     <form id="user-profile-form" class="space-y-4">
-                        <div>
-                            <label for="userProfileUid" class="block text-xs font-medium text-gray-600 mb-1">UID do Usuário (do Firebase Auth):</label>
-                            <div class="flex space-x-2">
-                                <input type="text" id="userProfileUid" value="${userToEdit?.id || ''}" class="${inputBaseClass} ${isCreating ? '' : 'bg-gray-100 cursor-not-allowed'}" ${isCreating ? '' : 'readonly'} required placeholder="Cole o UID do Firebase Auth aqui">
-                                ${isCreating ? `<button type="button" id="btn-create-auth-user" class="px-3 py-2 text-xs font-medium bg-blue-600 hover:bg-blue-700 text-white rounded-lg">Criar Usuário</button>` : ''}
-                            </div>
-                        </div>
+                        ${isCreating ? '<input type="hidden" id="userProfileUid">' : `<div><label for="userProfileUid" class="block text-xs font-medium text-gray-600 mb-1">UID do Usuário (do Firebase Auth):</label><input type="text" id="userProfileUid" value="${userToEdit?.id || ''}" class="${inputBaseClass} bg-gray-100 cursor-not-allowed" readonly></div>`}
                         <div><label for="userProfileName" class="block text-xs font-medium text-gray-600 mb-1">Nome Completo:</label>
                              <input type="text" id="userProfileName" value="${userToEdit?.name || ''}" class="${inputBaseClass}" required></div>
                         <div><label for="userProfileEmail" class="block text-xs font-medium text-gray-600 mb-1">Email:</label>
                              <input type="email" id="userProfileEmail" value="${userToEdit?.email || ''}" class="${inputBaseClass}" required placeholder="email.do.usuario@example.com"></div>
+                        ${isCreating ? `<div><label for="userProfilePassword" class="block text-xs font-medium text-gray-600 mb-1">Senha Inicial:</label><input type="password" id="userProfilePassword" class="${inputBaseClass}" required></div>` : ''}
                         <div><label for="userProfileSector" class="block text-xs font-medium text-gray-600 mb-1">Setor:</label>
                              <select id="userProfileSector" class="${inputBaseClass}">
                                  <option value="" ${!(userToEdit?.sector) ? 'selected': ''}>Nenhum</option>
@@ -2059,35 +2054,6 @@
                 </div>`;
 
             document.getElementById('btn-back-manage-users').onclick = () => { currentView = 'adminManageUsers'; renderApp(); };
-            if (isCreating) {
-                document.getElementById('btn-create-auth-user').addEventListener('click', () => {
-                    const email = document.getElementById('userProfileEmail').value.trim();
-                    if (!email) {
-                        showNotification('Preencha o email antes de criar o usuário.', 'error');
-                        return;
-                    }
-                    openModal(
-                        'Criar Usuário no Auth',
-                        '<div><label for="newAuthPassword" class="block text-sm font-medium text-gray-600 mb-1">Senha Inicial:</label><input type="password" id="newAuthPassword" class="w-full px-3 py-2 bg-white border border-gray-300 rounded-md text-gray-800 text-sm" required></div>',
-                        async () => {
-                            const pwd = document.getElementById('newAuthPassword').value;
-                            if (!pwd || pwd.length < 6) {
-                                showNotification('A senha deve ter pelo menos 6 caracteres.', 'error');
-                                throw new Error('Senha inválida');
-                            }
-                            try {
-                                const newUid = await createAuthUser(email, pwd);
-                                document.getElementById('userProfileUid').value = newUid;
-                                showNotification('Usuário criado no Firebase Auth!', 'success');
-                            } catch (err) {
-                                console.error('Erro ao criar usuário Auth:', err);
-                                showNotification('Erro ao criar usuário: ' + err.message, 'error');
-                                throw err;
-                            }
-                        }
-                    );
-                });
-            }
             document.getElementById('user-profile-form').addEventListener('submit', async (e) => {
                 e.preventDefault();
                 const submitButton = e.target.querySelector('button[type="submit"]');
@@ -2095,17 +2061,39 @@
                 submitButton.disabled = true;
                 submitButton.innerHTML = `<span class="flex items-center justify-center"><span class="loader_small_blue mr-2"></span>Processando...</span>`;
 
-                const uid = document.getElementById('userProfileUid').value.trim();
-                if (!uid) {
-                    showNotification("O UID do Usuário é obrigatório.", "error");
-                    submitButton.disabled = false;
-                    submitButton.innerHTML = originalButtonText;
-                    return;
+                let uid = document.getElementById('userProfileUid').value.trim();
+                const email = document.getElementById('userProfileEmail').value.trim();
+
+                if (isCreating) {
+                    const pwd = document.getElementById('userProfilePassword').value;
+                    if (!pwd || pwd.length < 6) {
+                        showNotification('A senha deve ter pelo menos 6 caracteres.', 'error');
+                        submitButton.disabled = false;
+                        submitButton.innerHTML = originalButtonText;
+                        return;
+                    }
+                    try {
+                        uid = await createAuthUser(email, pwd);
+                        document.getElementById('userProfileUid').value = uid;
+                    } catch (error) {
+                        console.error('Erro ao criar usuário Auth:', error);
+                        showNotification('Erro ao criar usuário: ' + error.message, 'error');
+                        submitButton.disabled = false;
+                        submitButton.innerHTML = originalButtonText;
+                        return;
+                    }
+                } else {
+                    if (!uid) {
+                        showNotification("O UID do Usuário é obrigatório.", "error");
+                        submitButton.disabled = false;
+                        submitButton.innerHTML = originalButtonText;
+                        return;
+                    }
                 }
 
                 const profileData = {
                     name: document.getElementById('userProfileName').value,
-                    email: document.getElementById('userProfileEmail').value,
+                    email: email,
                     sector: document.getElementById('userProfileSector').value,
                     isManager: document.getElementById('userProfileIsManager').checked,
                     isAdmin: document.getElementById('userProfileIsAdmin').checked,


### PR DESCRIPTION
## Summary
- automatically create Firebase Auth users and profiles in one step
- hide UID field on creation and request initial password instead
- handle user creation inside the profile form submission

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686bf12dff848331921f3e3090a23294