### PR TITLE
Fix modal invocation syntax

### DIFF
--- a/index.html
+++ b/index.html
@@ -1316,12 +1316,12 @@
                                     resolve();
                                 }
                             },
-                            'Sim, Adicionar',
+                            "Sim, Adicionar",
                             () => {
                                 showNotification("Adição de registro cancelada.", "info");
                                 resolve();
                             },
-                            'Não, Cancelar'
+                            "Não, Cancelar"
                         );
                     });
                 } else {


### PR DESCRIPTION
## Summary
- fix quote style for `openModal` call to avoid parsing issues

## Testing
- `node --check script_modified.js`

------
https://chatgpt.com/codex/tasks/task_e_687f9390759c83318538642de667a142