### PR TITLE
Allow managers to oversee multiple sectors

### DIFF
--- a/index.html
+++ b/index.html
@@ -533,7 +533,6 @@
                 const managerSectors = (userProfile.sectors && userProfile.sectors.length ? userProfile.sectors : userProfile.sector ? [userProfile.sector] : []);
                 if (dataKey === 'records') {
                     qConstraints.push(where("sector", "in", managerSectors));
-                    qConstraints.push(where("managerId", "==", currentUser.uid)); // Adicionando filtro por managerId para gestores
                 }
                 if (dataKey === 'employees') {
                     qConstraints.push(where("sector", "in", managerSectors));

--- a/index.html
+++ b/index.html
@@ -486,6 +486,7 @@
         // Atualiza a UI do cabeçalho com informações do usuário
         function updateHeaderUI() {
             if (userProfile) {
+                const managerSectorsText = (userProfile.sectors || [userProfile.sector]).filter(Boolean).join(', ');
                 userInfoHeader.innerHTML = `
                     <button id="btn-change-password" class="text-sm font-medium text-gray-600 hover:text-gray-700 py-2 px-3 rounded-lg hover:bg-gray-100 transition-colors duration-150 flex items-center space-x-1.5">
                         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect><path d="M7 11V7a5 5 0 0 1 10 0v4"></path></svg>
@@ -493,7 +494,7 @@
                     </button>
                     <span class="text-sm text-gray-600 hidden sm:block">
                         Olá, <span class="font-medium text-gray-800">${userProfile.name}</span>
-                        <span class="text-gray-400">(${userProfile.isAdmin ? 'Admin' : userProfile.isManager ? `Gestor - ${userProfile.sector}` : 'Usuário'})</span>
+                        <span class="text-gray-400">(${userProfile.isAdmin ? 'Admin' : userProfile.isManager ? `Gestor - ${managerSectorsText}` : 'Usuário'})</span>
                     </span>
                     <button id="logout-btn" class="text-sm font-medium text-blue-600 hover:text-blue-700 py-2 px-3 rounded-lg hover:bg-blue-50 transition-colors duration-150 flex items-center space-x-1.5">
                         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"></path><polyline points="16 17 21 12 16 7"></polyline><line x1="21" y1="12" x2="9" y2="12"></line></svg>
@@ -528,12 +529,15 @@
             let qConstraints = [...queryConstraints];
 
             // Filtra records e employees pelo setor do gestor, se não for admin
-            if (dataKey === 'records' && userProfile.isManager && !userProfile.isAdmin) {
-                qConstraints.push(where("sector", "==", userProfile.sector));
-                qConstraints.push(where("managerId", "==", currentUser.uid)); // Adicionando filtro por managerId para gestores
-            }
-            if (dataKey === 'employees' && userProfile.isManager && !userProfile.isAdmin) {
-                qConstraints.push(where("sector", "==", userProfile.sector));
+            if (userProfile.isManager && !userProfile.isAdmin) {
+                const managerSectors = (userProfile.sectors && userProfile.sectors.length ? userProfile.sectors : userProfile.sector ? [userProfile.sector] : []);
+                if (dataKey === 'records') {
+                    qConstraints.push(where("sector", "in", managerSectors));
+                    qConstraints.push(where("managerId", "==", currentUser.uid)); // Adicionando filtro por managerId para gestores
+                }
+                if (dataKey === 'employees') {
+                    qConstraints.push(where("sector", "in", managerSectors));
+                }
             }
 
             let q = query(collRef, ...qConstraints);
@@ -684,9 +688,10 @@
                 showNotification("Apenas gestores podem adicionar registros.", "error");
                 return Promise.reject(new Error("Acesso negado, não é gestor"));
             }
-            if (!userProfile.sector || userProfile.sector.trim() === "") {
+            const managerSectors = (userProfile.sectors && userProfile.sectors.length ? userProfile.sectors : userProfile.sector ? [userProfile.sector] : []);
+            if (managerSectors.length === 0) {
                 showNotification("Setor do gestor não definido no perfil. Não é possível salvar o registro. Contacte o administrador.", "error");
-                console.error("[addRecordToFirestore] Tentativa de salvar registro, mas userProfile.sector é indefinido ou vazio:", userProfile);
+                console.error("[addRecordToFirestore] Tentativa de salvar registro, mas userProfile.sectors é indefinido ou vazio:", userProfile);
                 return Promise.reject(new Error("Setor do gestor não definido"));
             }
 
@@ -695,7 +700,15 @@
                 return { success: false, error: "Fora do prazo" };
             }
 
-            const sectorName = (userProfile.sector || '').toLowerCase();
+            let employeeSector = (globalData.employees.find(emp => emp.id === recordData.employeeId)?.sector || '').toLowerCase();
+            if (recordData.employeeId === 'OUTROS') {
+                employeeSector = (managerSectors[0] || '').toLowerCase();
+            }
+            if (!managerSectors.map(s => s.toLowerCase()).includes(employeeSector)) {
+                showNotification("Funcionário não pertence a um setor gerenciado por você.", "error");
+                return { success: false, error: "Setor inválido" };
+            }
+            const sectorName = employeeSector;
 
             const ruleError = validateRecordWithRules(recordData, sectorName);
             if (ruleError) {
@@ -733,7 +746,7 @@
                     ...recordData,
                     managerId: currentUser.uid,
                     managerName: userProfile.name,
-                    sector: userProfile.sector,
+                    sector: sectorName,
                     createdAt: Timestamp.now()
                 };
                 console.log("[addRecordToFirestore] Dados para salvar:", dataToSave);
@@ -1174,10 +1187,11 @@
 
         // Renderiza o painel do gestor
         function renderManagerDashboard() {
+            const managerSectorsText = (userProfile.sectors || [userProfile.sector]).filter(Boolean).join(', ');
             appContent.innerHTML = `
                 <div class="animate-fadeIn bg-white p-6 sm:p-8 rounded-xl shadow-lg border border-gray-200">
                     <h2 class="text-2xl font-semibold text-gray-800 mb-1">Bem-vindo, Gestor <span class="text-blue-600">${userProfile.name}</span>!</h2>
-                    <p class="text-gray-500 mb-6 text-sm">Setor: <span class="font-medium text-gray-700">${userProfile.sector}</span>. Utilize as opções abaixo.</p>
+                    <p class="text-gray-500 mb-6 text-sm">Setor(es): <span class="font-medium text-gray-700">${managerSectorsText}</span>. Utilize as opções abaixo.</p>
                     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mt-8">
                         <button id="btn-new-record" class="flex flex-col items-center justify-center text-center p-6 bg-gray-50 hover:bg-gray-100 text-gray-700 font-medium rounded-lg transition-all duration-150 ease-in-out border border-gray-200 hover:border-gray-300 shadow-sm hover:shadow-md">
                             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="mb-2 text-blue-600 size-6"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" /></svg>
@@ -1202,8 +1216,9 @@
         // Renderiza o formulário para inclusão de novo registro
         function renderNewRecordForm() {
             const categoriesOptions = globalData.categories.map(cat => `<option value="${cat.id}">${cat.name} - ${cat.description}</option>`).join('');
-            // Filtra funcionários pelo setor do gestor, se não for admin
-            const employeesFilteredBySector = userProfile.isAdmin ? globalData.employees : globalData.employees.filter(emp => emp.sector === userProfile.sector);
+            // Filtra funcionários pelos setores do gestor, se não for admin
+            const managerSectors = userProfile.isAdmin ? [] : (userProfile.sectors || [userProfile.sector]);
+            const employeesFilteredBySector = userProfile.isAdmin ? globalData.employees : globalData.employees.filter(emp => managerSectors.includes(emp.sector));
             const employeesOptions = employeesFilteredBySector.map(emp => `<option value="${emp.id}">${emp.name} (${emp.registration}) - ${emp.sector}</option>`).join('') + '<option value="OUTROS">Outros</option>';
             const inputBaseClass = "w-full px-3 py-2.5 bg-white border border-gray-300 rounded-lg text-gray-800 placeholder-gray-400 text-sm focus:ring-1 focus:ring-blue-500 focus:border-blue-500 outline-none transition-colors";
 
@@ -1357,10 +1372,10 @@
             const mainSheetName = "Registros";
             const listsSheetName = "Listas"; // Name for the lists sheet
 
-            // Filter employees by manager's sector if not admin, otherwise get all
+            // Filter employees by manager's sectors if not admin, otherwise get all
             const employeesForLists = (userProfile.isAdmin
                 ? globalData.employees.map(emp => emp.name)
-                : globalData.employees.filter(emp => emp.sector === userProfile.sector).map(emp => emp.name))
+                : globalData.employees.filter(emp => (userProfile.sectors || [userProfile.sector]).includes(emp.sector)).map(emp => emp.name))
                 .concat('Outros');
 
             // Create workbook and main sheet
@@ -1543,10 +1558,11 @@
                                 employeeId = 'OUTROS';
                                 finalEmployeeName = notes.trim();
                             } else {
-                                const employeesInSector = userProfile.isAdmin ? globalData.employees : globalData.employees.filter(emp => emp.sector === userProfile.sector);
+                                const managerSectors = userProfile.isAdmin ? [] : (userProfile.sectors || [userProfile.sector]);
+                                const employeesInSector = userProfile.isAdmin ? globalData.employees : globalData.employees.filter(emp => managerSectors.includes(emp.sector));
                                 const employee = employeesInSector.find(emp => emp.name?.toLowerCase() === employeeName.toLowerCase());
                                 if (!employee) {
-                                    throw new Error(`Funcionário '${employeeName}' não encontrado ou não pertence ao seu setor ('${userProfile.sector}').`);
+                                    throw new Error(`Funcionário '${employeeName}' não encontrado ou não pertence aos seus setores ('${managerSectors.join(', ')}').`);
                                 }
                                 employeeId = employee.id;
                                 finalEmployeeName = employee.name;
@@ -1707,7 +1723,7 @@
                         <td class="px-4 py-2 text-[11px] text-gray-600 whitespace-nowrap">${record.managerName}</td>
                         <td class="px-4 py-2 text-[11px] text-gray-500 max-w-xs truncate" title="${record.notes || ''}">${record.notes || '-'}</td>
                         <!-- Coluna de Ação visível se o usuário for gestor do setor do registro ou admin -->
-                        ${(userProfile.isManager && record.sector === userProfile.sector && !userProfile.isAdmin && record.managerId === currentUser.uid) || userProfile.isAdmin ?
+                        ${(userProfile.isManager && (userProfile.sectors || [userProfile.sector]).includes(record.sector) && !userProfile.isAdmin && record.managerId === currentUser.uid) || userProfile.isAdmin ?
                             `<td class="px-4 py-2 text-[11px] text-center">
                                 <button class="btn-delete-record text-red-500 hover:text-red-700 p-1 hover:bg-red-50 rounded-md" data-id="${record.id}" title="Excluir Registro">
                                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 6 5 6 21 6"></polyline><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path></svg>
@@ -1831,7 +1847,7 @@
                     <div class="flex flex-col md:flex-row justify-between items-start md:items-center mb-6">
                         <div>
                             <h2 class="text-xl font-semibold text-gray-800">Histórico de Registros</h2>
-                            ${userProfile.isManager && !userProfile.isAdmin ? `<p class="text-xs text-gray-500 mt-0.5">Setor: ${userProfile.sector}</p>` : ''}
+                            ${userProfile.isManager && !userProfile.isAdmin ? `<p class="text-xs text-gray-500 mt-0.5">Setor(es): ${(userProfile.sectors || [userProfile.sector]).filter(Boolean).join(', ')}</p>` : ''}
                         </div>
                         <div class="flex items-center space-x-2 mt-3 md:mt-0">
                             <button id="btn-export-csv" class="px-3 py-1.5 text-xs font-medium bg-green-600 hover:bg-green-700 text-white rounded-lg flex items-center"><svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="mr-1"><path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path><circle cx="9" cy="7" r="4"></circle><path d="M22 21v-2a4 4 0 0 0-3-3.87"></path><path d="M16 3.13a4 4 0 0 1 0 7.75"></path></svg>CSV</button>
@@ -2325,9 +2341,11 @@
         function renderAdminCreateUserProfilePage(userToEdit = null) {
             const isCreating = !userToEdit;
             const cdn = collectionDisplayName('users_profile');
-            const sectorsOptionsHtml = globalData.sectors.map(s => `<option value="${s.name}" ${userToEdit?.sector === s.name ? 'selected' : ''}>${s.name}</option>`).join('');
-            const inputBaseClass = "w-full px-3 py-2 bg-white border border-gray-300 rounded-md text-gray-800 placeholder-gray-400 text-sm focus:ring-1 focus:ring-blue-500 focus:border-blue-500 outline-none transition-colors";
             const checkboxClass = "h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500";
+            const sectorsCheckboxesHtml = globalData.sectors.map(s =>
+                `<label class=\"flex items-center space-x-2\"><input type=\"checkbox\" name=\"userProfileSector\" value=\"${s.name}\" class=\"${checkboxClass}\" ${(userToEdit?.sectors || []).includes(s.name) ? 'checked' : ''}><span>${s.name}</span></label>`
+            ).join('');
+            const inputBaseClass = "w-full px-3 py-2 bg-white border border-gray-300 rounded-md text-gray-800 placeholder-gray-400 text-sm focus:ring-1 focus:ring-blue-500 focus:border-blue-500 outline-none transition-colors";
 
             const pageTitle = isCreating ? "Criar Novo Perfil de Usuário" : `Editar Perfil: ${userToEdit.name}`;
 
@@ -2344,11 +2362,10 @@
                         <div><label for="userProfileEmail" class="block text-xs font-medium text-gray-600 mb-1">Email:</label>
                              <input type="email" id="userProfileEmail" value="${userToEdit?.email || ''}" class="${inputBaseClass}" required placeholder="email.do.usuario@example.com"></div>
                         ${isCreating ? `<div><label for="userProfilePassword" class="block text-xs font-medium text-gray-600 mb-1">Senha Inicial:</label><input type="password" id="userProfilePassword" class="${inputBaseClass}" required></div>` : ''}
-                        <div><label for="userProfileSector" class="block text-xs font-medium text-gray-600 mb-1">Setor:</label>
-                             <select id="userProfileSector" class="${inputBaseClass}">
-                                 <option value="" ${!(userToEdit?.sector) ? 'selected': ''}>Nenhum</option>
-                                 ${sectorsOptionsHtml}
-                             </select></div>
+                        <div><span class="block text-xs font-medium text-gray-600 mb-1">Setor(es):</span>
+                             <div id="userProfileSectors" class="flex flex-col space-y-1">
+                                 ${sectorsCheckboxesHtml}
+                             </div></div>
                         <div class="grid grid-cols-2 gap-4 pt-1">
                             <label class="flex items-center space-x-2 text-sm text-gray-700"><input type="checkbox" id="userProfileIsManager" ${userToEdit?.isManager ? 'checked' : ''} class="${checkboxClass}"><span>É Gestor?</span></label>
                             <label class="flex items-center space-x-2 text-sm text-gray-700"><input type="checkbox" id="userProfileIsAdmin" ${userToEdit?.isAdmin ? 'checked' : ''} class="${checkboxClass}"><span>É Admin?</span></label>
@@ -2398,14 +2415,26 @@
                     }
                 }
 
+                const selectedSectors = Array.from(document.querySelectorAll('input[name="userProfileSector"]:checked')).map(opt => opt.value);
+
                 const profileData = {
                     name: document.getElementById('userProfileName').value,
                     email: email,
-                    sector: document.getElementById('userProfileSector').value,
+                    sectors: selectedSectors,
+                    sector: selectedSectors[0] || '',
                     isManager: document.getElementById('userProfileIsManager').checked,
                     isAdmin: document.getElementById('userProfileIsAdmin').checked,
                     uid: uid
                 };
+
+                if (profileData.isManager && profileData.sectors.length > 1) {
+                    const proceed = confirm('Este gestor está sendo atribuído a múltiplos setores. Deseja prosseguir?');
+                    if (!proceed) {
+                        submitButton.disabled = false;
+                        submitButton.innerHTML = originalButtonText;
+                        return;
+                    }
+                }
 
                 try {
                     const userDocRef = doc(getCollectionRef('users_profile', false), uid);
@@ -2439,7 +2468,7 @@
                 <tr class="hover:bg-gray-50 transition-colors">
                     <td class="px-5 py-3 text-xs text-gray-700 font-medium whitespace-nowrap">${user.name || 'N/A'}</td>
                     <td class="px-5 py-3 text-xs text-gray-600 whitespace-nowrap">${user.email}</td>
-                    <td class="px-5 py-3 text-xs text-gray-600 whitespace-nowrap">${user.sector || 'N/A'}</td>
+                    <td class="px-5 py-3 text-xs text-gray-600 whitespace-nowrap">${(user.sectors && user.sectors.length) ? user.sectors.join(', ') : (user.sector || 'N/A')}</td>
                     <td class="px-5 py-3 text-xs text-gray-600 whitespace-nowrap">${user.isManager ? '<span class="px-2 py-0.5 inline-flex text-xxs leading-5 font-semibold rounded-full bg-green-100 text-green-800">Sim</span>' : '<span class="px-2 py-0.5 inline-flex text-xxs leading-5 font-semibold rounded-full bg-red-100 text-red-800">Não</span>'}</td>
                     <td class="px-5 py-3 text-xs text-gray-600 whitespace-nowrap">${user.isAdmin ? '<span class="px-2 py-0.5 inline-flex text-xxs leading-5 font-semibold rounded-full bg-blue-100 text-blue-800">Sim</span>' : '<span class="px-2 py-0.5 inline-flex text-xxs leading-5 font-semibold rounded-full bg-red-100 text-red-800">Não</span>'}</td>
                     <td class="px-5 py-3 text-xs font-medium whitespace-nowrap space-x-2">
@@ -2472,7 +2501,7 @@
                                 <thead class="bg-gray-50"><tr>
                                     <th class="px-5 py-2.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Nome</th>
                                     <th class="px-5 py-2.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Email</th>
-                                    <th class="px-5 py-2.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Setor</th>
+                                    <th class="px-5 py-2.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Setor(es)</th>
                                     <th class="px-5 py-2.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Gestor?</th>
                                     <th class="px-5 py-2.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Admin?</th>
                                     <th class="px-5 py-2.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Ações</th>


### PR DESCRIPTION
## Summary
- support multiple sector selection when editing a user profile and prompt for confirmation if a manager spans sectors
- update queries, filtering and record creation to handle managers responsible for multiple sectors
- replace sector multi-select with checkboxes for clearer selection

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/qmsafbotafogo/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_6890bd75c4b483319dba8f06ef7146cd